### PR TITLE
mod: より頻繁に実行する

### DIFF
--- a/sre.json
+++ b/sre.json
@@ -12,14 +12,16 @@
     "excluded from findy"
   ],
   "schedule": [
-    "after 10pm on Sunday",
     "before 5am on Monday",
     "after 10pm on Monday",
     "before 5am on Tuesday",
+    "after 10pm on Tuesday",
+    "before 5am on Wednesday",
     "after 10pm on Wednesday",
     "before 5am on Thursday",
     "after 10pm on Thursday",
-    "before 5am on Friday"
+    "before 5am on Friday",
+    "every weekend"
   ],
   "platformAutomerge": true
 }


### PR DESCRIPTION
以前は定例会などイベント多い日である水曜にrenovateがたまらないように、という設定をしていましたが、
正直そこまで手動mergeしてない && auto merge運用開始したので、火夜〜水朝も実行していいのでは？

あと週末は終日実行でもいいかと思いましたが、
ここを除外していた背景を思い出せず、懸念があれば `every weekend` をやめます。