### PR TITLE
add: TerraformをAtlantisで動かす場合のルール追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # renovate-config
 
-| File                         | Description                                                   |
-| :--------------------------- | :------------------------------------------------------------ |
-| pinGitHubActions.json        | GitHub Actionsの推奨設定                                      |
-| sre.json                     | SREチームの利用推奨設定 (pinGitHubActionsを内包)              |
-| terraform-with-atlantis.json | Atlantisで実行するTerraformの推奨設定、auto merge有効化を前提 |
+| File                       | Description                                                   |
+| :------------------------- | :------------------------------------------------------------ |
+| pinGitHubActions.json      | GitHub Actionsの推奨設定                                      |
+| sre.json                   | SREチームの利用推奨設定 (pinGitHubActionsを内包)              |
+| terraformWithAtlantis.json | Atlantisで実行するTerraformの推奨設定、auto merge有効化を前提 |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # renovate-config
+
+| File                         | Description                                                   |
+| :--------------------------- | :------------------------------------------------------------ |
+| pinGitHubActions.json        | GitHub Actionsの推奨設定                                      |
+| sre.json                     | SREチームの利用推奨設定 (pinGitHubActionsを内包)              |
+| terraform-with-atlantis.json | Atlantisで実行するTerraformの推奨設定、auto merge有効化を前提 |

--- a/terraform-with-atlantis.json
+++ b/terraform-with-atlantis.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "platformAutomerge": true,
+  "rebaseWhen": "never",
+  "prHourlyLimit": 1,
+  "enabledManagers": [
+    "terraform"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "^app.terraform.io/gdp-sre",
+        "terraform-aws-modules/eks/aws"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchDepTypes": [
+        "helm_release"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "terraform"
+      ],
+      "additionalBranchPrefix": "{{packageFileDir}}-",
+      "commitMessageSuffix": "({{packageFileDir}})",
+      "groupName": "terraform state",
+      "groupSlug": "tfstate",
+      "automerge": true,
+      "major": {
+        "automerge": false
+      }
+    },
+    {
+      "matchManagers": [
+        "terraform"
+      ],
+      "additionalBranchPrefix": "{{packageFileDir}}-",
+      "commitMessageSuffix": "({{packageFileDir}})",
+      "description": "terraform local modules",
+      "groupName": "terraform modules",
+      "groupSlug": "tfmodules",
+      "matchFileNames": ["**/modules/**"],
+      "automerge": true,
+      "major": {
+        "automerge": false
+      },
+      "rangeStrategy": "auto"
+    }
+  ]
+}

--- a/terraformWithAtlantis.json
+++ b/terraformWithAtlantis.json
@@ -1,16 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "platformAutomerge": true,
   "rebaseWhen": "never",
   "prHourlyLimit": 1,
-  "enabledManagers": [
-    "terraform"
-  ],
   "packageRules": [
     {
+      "matchManagers": [
+        "terraform"
+      ],
       "matchPackagePatterns": [
         "^app.terraform.io/gdp-sre",
-        "terraform-aws-modules/eks/aws"
       ],
       "enabled": false
     },


### PR DESCRIPTION
TerraformをAtlantisで動かしている場合の推奨設定ファイルを追加。
auto mergeを有効活用するための設定としています。

`sre.json` と組み合わせて使うことを想定しているため、 `extends` していません。