### PR TITLE
feat: HCP Terraform 用の renovate config を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # renovate-config
 
-| File                       | Description                                                   |
-| :------------------------- | :------------------------------------------------------------ |
-| pinGitHubActions.json      | GitHub Actionsの推奨設定                                      |
-| sre.json                   | SREチームの利用推奨設定 (pinGitHubActionsを内包)              |
-| terraformWithAtlantis.json | Atlantisで実行するTerraformの推奨設定、auto merge有効化を前提 |
+| File                  | Description                                                  |
+|:----------------------|:-------------------------------------------------------------|
+| pinGitHubActions.json | GitHub Actionsの推奨設定                                      |
+| sre.json              | SREチームの利用推奨設定 (pinGitHubActionsを内包)                  |
+| terraform.json        | Terraform用のpackageRulesの推奨設定                            |
+| atlantis.json         | Atlantisで実行するTerraformの推奨設定、auto merge有効化を前提      |
+| hcp.json              | HCP Terraformで実行するTerraformの推奨設定、auto merge無効化を前提 |

--- a/atlantis.json
+++ b/atlantis.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>globis-org/renovate-config:terraform"
+  ],
+  "prHourlyLimit": 1,
+  "rebaseWhen": "never"
+}

--- a/hcp.json
+++ b/hcp.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>globis-org/renovate-config:terraform"
+  ],
+  "prHourlyLimit": 0,
+  "rebaseWhen": "never",
+  "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "automerge": false
+    }
+  ]
+}

--- a/terraform.json
+++ b/terraform.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["terraform"],
+      "matchPackagePatterns": ["^app.terraform.io/gdp-sre"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["terraform"],
+      "matchDepTypes": ["helm_release"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["terraform"],
+      "additionalBranchPrefix": "{{packageFileDir}}-",
+      "commitMessageSuffix": "({{packageFileDir}})",
+      "groupName": "terraform state",
+      "groupSlug": "tfstate",
+      "automerge": true,
+      "major": {
+        "automerge": false
+      },
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchManagers": ["terraform"],
+      "additionalBranchPrefix": "{{packageFileDir}}-",
+      "commitMessageSuffix": "({{packageFileDir}})",
+      "description": "terraform local modules",
+      "groupName": "terraform modules",
+      "groupSlug": "tfmodules",
+      "matchFileNames": ["**/modules/**"],
+      "automerge": true,
+      "major": {
+        "automerge": false
+      },
+      "rangeStrategy": "auto"
+    }
+  ]
+}


### PR DESCRIPTION
- HCP Terraform 用の設定を追加する
- atlantis と重複する部分が多いので共通設定を切り出す
- 影響範囲を限定するために `terraformWithAtlantis.json` は残しておく
  - 今後は `altantis.json` を使ってもらう想定