### PR TITLE
chore: 一時的にrenovateでterraform 1.8.2以上へは上げない

### DIFF
--- a/terraformWithAtlantis.json
+++ b/terraformWithAtlantis.json
@@ -25,6 +25,15 @@
       "matchManagers": [
         "terraform"
       ],
+      "matchPackageNames": [
+        "terraform"
+      ],
+      "allowedVersions": "<=1.8.1"
+    },
+    {
+      "matchManagers": [
+        "terraform"
+      ],
       "additionalBranchPrefix": "{{packageFileDir}}-",
       "commitMessageSuffix": "({{packageFileDir}})",
       "groupName": "terraform state",


### PR DESCRIPTION
* https://github.com/globis-org/core-infra/issues/2670
* 現在のAtlantisではTerraform 1.8.2以上が使えなくなっているため。