### PR TITLE
fix: 誤った設定を修正

### DIFF
--- a/terraformWithAtlantis.json
+++ b/terraformWithAtlantis.json
@@ -25,8 +25,8 @@
       "matchManagers": [
         "terraform"
       ],
-      "matchPackageNames": [
-        "terraform"
+      "matchDepTypes": [
+        "required_version"
       ],
       "allowedVersions": "<=1.8.1"
     },


### PR DESCRIPTION
* Terraform <= 1.8.1 の範囲で更新させたかったが動作しなかった
* 以下を参考にすると required_version の depType で条件を書けばうまくいくのでは
    * https://docs.renovatebot.com/modules/manager/terraform/#disabling-parts-of-the-manager