### PR TITLE
mod: AtlantisでTerraform 1.8.2以上も使用可能になった

### DIFF
--- a/atlantis.json
+++ b/atlantis.json
@@ -8,8 +8,7 @@
   "packageRules": [
     {
       "matchManagers": ["terraform"],
-      "matchDepTypes": ["required_version"],
-      "allowedVersions": "<=1.8.1"
+      "matchDepTypes": ["required_version"]
     }
   ]
 }


### PR DESCRIPTION
* Atlantis 0.29.0で、Terraform 1.8.2以上も動作可能になった。
  * https://github.com/globis-org/aws-products-infra/pull/5846 で動作確認済み。