### PR TITLE
GHAのmajor verのみ指定してもpatchまで固定されるようにする

### DIFF
--- a/pinGitHubActions.json
+++ b/pinGitHubActions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
> 補足ですが Renovate の場合 helpers:pinGitHubActionDigestsToSemver という Preset を使うと major バージョンしか指定してない場合でも full の version に置換してくれます。
> [XユーザーのShunsuke Suzukiさん: 「補足ですが Renovate の場合 helpers:pinGitHubActionDigestsToSemver という Preset を使うと major バージョンしか指定してない場合でも full の version に置換してくれます。 https://t.co/Em5z9D7qh4」 / X](https://x.com/szkdash/status/1901776687253393522)

* ↑こちらを見かけたので。
* 今までは下図のような挙動で、majorバージョンのみを指定していると、SHAを更新してくれつつバージョン番号表記の更新は入らなかったのですが、これを解消してくれるもの、と読んでいます。
    * https://github.com/globis-org/infra-dockerfiles/commit/b3c0b144c55f6aaaf66b855244fb8eb170ff91ea

<img width="1712" alt="image" src="https://github.com/user-attachments/assets/101fc8df-5ac5-4f9c-bc39-805e0d7b1bd3" />

* 従来使っていた `pinGitHubActionDigests` をラップして設定追加したhelperのようなので、何か不具合は出ないと想定。
    * cf: [Helper Presets - Renovate Docs](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests)