### PR TITLE
mod:スケジュールの時間を変更

### DIFF
--- a/sre.json
+++ b/sre.json
@@ -12,15 +12,15 @@
     "excluded from findy"
   ],
   "schedule": [
-    "before 5am on Monday",
-    "after 10pm on Monday",
-    "before 5am on Tuesday",
-    "after 10pm on Tuesday",
-    "before 5am on Wednesday",
-    "after 10pm on Wednesday",
-    "before 5am on Thursday",
-    "after 10pm on Thursday",
-    "before 5am on Friday",
+    "before 8am on Monday",
+    "after 9pm on Monday",
+    "before 8am on Tuesday",
+    "after 9pm on Tuesday",
+    "before 8am on Wednesday",
+    "after 9pm on Wednesday",
+    "before 8am on Thursday",
+    "after 9pm on Thursday",
+    "before 8am on Friday",
     "every weekend"
   ],
   "platformAutomerge": true


### PR DESCRIPTION


### Description
関連: https://github.com/globis-org/aws-products-infra/pull/7519
renovateのPR処理数を改善する為の修正です。スケジュール時間帯を修正します。

* 月曜日から金曜日の時間をそれぞれ8時前と9時以降に更新
* 始業、終業時間の実態に併せて修正

### 影響範囲

* サービス影響：無（相談ベース）

### レビューポイント

* 

### レビュー期限

* お手すきで
