### PR TITLE
Terraform IAM Module にメジャーバージョン制限を入れる

### DIFF
--- a/terraform.json
+++ b/terraform.json
@@ -8,6 +8,12 @@
     },
     {
       "matchManagers": ["terraform"],
+      "matchPackageNames": ["terraform-aws-modules/iam/aws"],
+      "allowedVersions": "<6.0.0",
+      "description": "Restrict IAM module to v5.x due to breaking changes in v6"
+    },
+    {
+      "matchManagers": ["terraform"],
       "additionalBranchPrefix": "{{packageFileDir}}-",
       "commitMessageSuffix": "({{packageFileDir}})",
       "groupName": "terraform state",


### PR DESCRIPTION
- v6 で破壊的変更があるので一旦止める
  - https://github.com/terraform-aws-modules/terraform-aws-iam